### PR TITLE
Use `strict_encode64` for basic authentication

### DIFF
--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -31,7 +31,7 @@ module OAuth2
     end
 
     def self.encode_basic_auth(user, password)
-      'Basic ' + Base64.encode64(user + ':' + password).delete("\n")
+      'Basic ' + Base64.strict_encode64(user + ':' + password)
     end
 
   private


### PR DESCRIPTION
`Base64.strict_encode64` method doesn't need to remove the `"\n"` characters a posteriori.